### PR TITLE
6 after model utility

### DIFF
--- a/addon/utils/notify-after-load.js
+++ b/addon/utils/notify-after-load.js
@@ -1,10 +1,10 @@
 import { allSettled } from 'ember-concurrency';
 
-export default async function notifyAfterLoad(hash, callback) {
+export default function notifyAfterLoad(hash, callback) {
   allSettled(Object.values(hash))
     .then(() => {
       callback(hash);
     });
 
   return hash;
-};
+}

--- a/addon/utils/notify-after-load.js
+++ b/addon/utils/notify-after-load.js
@@ -1,0 +1,13 @@
+import { waitForProperty } from 'ember-concurrency';
+
+export default async function notifyAfterLoad(hash, callback) {
+  await waitForProperty(
+    Object.values(hash),
+    'state',
+    'finished',
+  );
+
+  callback(hash);
+
+  return hash;
+};

--- a/addon/utils/notify-after-load.js
+++ b/addon/utils/notify-after-load.js
@@ -1,13 +1,10 @@
-import { waitForProperty } from 'ember-concurrency';
+import { allSettled } from 'ember-concurrency';
 
 export default async function notifyAfterLoad(hash, callback) {
-  await waitForProperty(
-    Object.values(hash),
-    'state',
-    'finished',
-  );
-
-  callback(hash);
+  allSettled(Object.values(hash))
+    .then(() => {
+      callback(hash);
+    });
 
   return hash;
 };

--- a/app/utils/notify-after-load.js
+++ b/app/utils/notify-after-load.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-tasks/utils/notify-after-load';

--- a/tests/unit/utils/notify-after-load-test.js
+++ b/tests/unit/utils/notify-after-load-test.js
@@ -1,0 +1,10 @@
+import notifyAfterLoad from 'dummy/utils/notify-after-load';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | notify after load');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = notifyAfterLoad();
+  assert.ok(result);
+});


### PR DESCRIPTION
This pull request adds a simple utility function `notifyAfterLoad` that performs a given callback after a hash of data tasks have settled. This closes #6.

For example, this can be used in the model hook and wraps the normal data task hash:
```javascript
model({ id }) {
    return notifyAfterLoad({
      taskInstance: this.store.findRecord('lot', id),
    }, (hash) => {
      alert("all settled! do other stuff");
    });
}
```

The function signature of the callback will be the hash itself in a `finished` state.

Not quite sure how to write an automated test for this sort of thing given [the state of testing concurrency](http://ember-concurrency.com/docs/testing-debugging).

